### PR TITLE
Display project insights within portfolio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,6 +322,22 @@
                     <a href="#" class="text-blue-600 hover:text-blue-800 font-semibold text-sm">View Project &rarr;</a>
                 </div>
             </div>
+            <div id="projectInsightArea" class="mt-8 space-y-4">
+                <div id="projectLoadingIndicator" class="hidden text-sm text-gray-500 flex items-center gap-2">
+                    <svg class="animate-spin h-4 w-4 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <span>Generating project insight...</span>
+                </div>
+                <div id="projectInsightContainer" class="hidden p-4 bg-blue-50 border border-blue-100 rounded-lg">
+                    <h4 id="projectInsightTitle" class="font-semibold text-blue-900">Project Insight</h4>
+                    <p id="projectInsightText" class="mt-2 text-sm text-blue-900"></p>
+                </div>
+                <div id="projectErrorContainer" class="hidden p-4 bg-red-100 border border-red-200 rounded-lg">
+                    <p id="projectErrorMessage" class="text-sm text-red-700"></p>
+                </div>
+            </div>
         </section>
 
         <!-- Academic Publications -->


### PR DESCRIPTION
## Summary
- add a dedicated project insight panel beneath the portfolio grid to surface generated summaries where projects are shown
- extend the insight generation helper to target custom loading/result/error elements so project insights no longer reuse the AI generator output area
- scope project-specific messaging to the portfolio section while keeping the existing AI Thought Leadership Generator behavior unchanged

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5511bf6ec832da320e9cf3a9830d6