### PR TITLE
Add AI-driven insights for academic publications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+api/node_modules/

--- a/index.html
+++ b/index.html
@@ -367,21 +367,61 @@
                     <h4 class="font-bold text-blue-700" data-title="Computational Estimation of Microsecond to Second Atomistic Folding Times">Computational Estimation of Microsecond to Second Atomistic Folding Times</h4>
                     <p class="text-sm italic mb-2">Published in *Journal of the American Chemical Society*, 2019</p>
                     <p class="publication-description" data-description="A research paper on developing computational methods for simulating and analyzing protein-ligand binding, which has implications for drug discovery.">A research paper on developing computational methods for simulating and analyzing protein-ligand binding, which has implications for drug discovery.</p>
+                    <button type="button" class="generate-publication-insight mt-4 inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md px-3 py-2 bg-blue-50 hover:bg-blue-100 transition">
+                        <span>Generate publication insight</span>
+                        <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                        </svg>
+                    </button>
                 </div>
                 <div class="publication-item bg-gray-50 p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                     <h4 class="font-bold text-blue-700" data-title="Middle-way flexible docking: Pose prediction using mixed-resolution Monte Carlo in estrogen receptor $\alpha$">Middle-way flexible docking: Pose prediction using mixed-resolution Monte Carlo in estrogen receptor α</h4>
                     <p class="text-sm italic mb-2">Published in *PloS one*, 2019</p>
                     <p class="publication-description" data-description="A publication focused on using a combined resolution approach with Monte Carlo simulations to predict the poses of molecules binding to estrogen receptors, a key step in computational drug design.">A publication focused on using a combined resolution approach with Monte Carlo simulations to predict the poses of molecules binding to estrogen receptors, a key step in computational drug design.</p>
+                    <button type="button" class="generate-publication-insight mt-4 inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md px-3 py-2 bg-blue-50 hover:bg-blue-100 transition">
+                        <span>Generate publication insight</span>
+                        <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                        </svg>
+                    </button>
                 </div>
                 <div class="publication-item bg-gray-50 p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                     <h4 class="font-bold text-blue-700" data-title="Role of length-dependent stability of collagen-like peptides">Role of length-dependent stability of collagen-like peptides</h4>
                     <p class="text-sm italic mb-2">Published in *The Journal of Physical Chemistry B*, 2008</p>
                     <p class="publication-description" data-description="An early career research paper using molecular dynamics to investigate the stability of collagen-like peptides based on their length, highlighting foundational work in molecular simulation.">An early career research paper using molecular dynamics to investigate the stability of collagen-like peptides based on their length, highlighting foundational work in molecular simulation.</p>
+                    <button type="button" class="generate-publication-insight mt-4 inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md px-3 py-2 bg-blue-50 hover:bg-blue-100 transition">
+                        <span>Generate publication insight</span>
+                        <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                        </svg>
+                    </button>
                 </div>
                 <div class="publication-item bg-gray-50 p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                     <h4 class="font-bold text-blue-700" data-title="Exploring the changes in the structure of $\alpha$-helical peptides adsorbed onto a single walled carbon nanotube using classical molecular dynamics simulation">Exploring the changes in the structure of α-helical peptides adsorbed onto a single walled carbon nanotube using classical molecular dynamics simulation</h4>
                     <p class="text-sm italic mb-2">Published in *The Journal of Physical Chemistry B*, 2010</p>
                     <p class="publication-description" data-description="A research article detailing the use of classical molecular dynamics to analyze how the structure of α-helical peptides changes when they interact with carbon nanotubes, a topic with applications in bionanotechnology.">A research article detailing the use of classical molecular dynamics to analyze how the structure of α-helical peptides changes when they interact with carbon nanotubes, a topic with applications in bionanotechnology.</p>
+                    <button type="button" class="generate-publication-insight mt-4 inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md px-3 py-2 bg-blue-50 hover:bg-blue-100 transition">
+                        <span>Generate publication insight</span>
+                        <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                        </svg>
+                    </button>
+                </div>
+                <div id="publicationInsightArea" class="mt-8 space-y-4">
+                    <div id="publicationLoadingIndicator" class="hidden text-sm text-gray-500 flex items-center gap-2">
+                        <svg class="animate-spin h-4 w-4 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        <span>Generating publication insight...</span>
+                    </div>
+                    <div id="publicationInsightContainer" class="hidden p-4 bg-blue-50 border border-blue-100 rounded-lg">
+                        <h4 id="publicationInsightTitle" class="font-semibold text-blue-900">Publication Insight</h4>
+                        <p id="publicationInsightText" class="mt-2 text-sm text-blue-900"></p>
+                    </div>
+                    <div id="publicationErrorContainer" class="hidden p-4 bg-red-100 border border-red-200 rounded-lg">
+                        <p id="publicationErrorMessage" class="text-sm text-red-700"></p>
+                    </div>
                 </div>
             </div>
         </section>

--- a/scripts.js
+++ b/scripts.js
@@ -149,6 +149,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const projectErrorContainer = document.getElementById('projectErrorContainer');
     const projectErrorMessage = document.getElementById('projectErrorMessage');
 
+    const publicationLoadingIndicator = document.getElementById('publicationLoadingIndicator');
+    const publicationInsightContainer = document.getElementById('publicationInsightContainer');
+    const publicationInsightTitle = document.getElementById('publicationInsightTitle');
+    const publicationInsightText = document.getElementById('publicationInsightText');
+    const publicationErrorContainer = document.getElementById('publicationErrorContainer');
+    const publicationErrorMessage = document.getElementById('publicationErrorMessage');
+
     const publications = [
         { id: 'pub1', title: 'Computational Estimation of Microsecond to Second Atomistic Folding Times', description: 'A research paper on developing computational methods for simulating and analyzing protein-ligand binding, which has implications for drug discovery.' },
         { id: 'pub2', title: 'Middle-way flexible docking', description: 'A publication focused on using a combined resolution approach with Monte Carlo simulations to predict the poses of molecules binding to estrogen receptors, a key step in computational drug design.' },
@@ -259,6 +266,12 @@ document.addEventListener('DOMContentLoaded', () => {
         return `Summarise the selected project "${safeTitle}".${detailSentence} Focus on the objectives, approach, and impact in two to three sentences.`;
     };
 
+    const generatePublicationPrompt = (title, description) => {
+        const safeTitle = title || 'the selected publication';
+        const detailSentence = description ? ` Here are the available details: ${description}` : '';
+        return `Summarise the key contribution of the publication "${safeTitle}".${detailSentence} Highlight the research problem, methodology, findings, and potential real-world impact in two to three sentences suitable for an executive profile.`;
+    };
+
     generateBtn.addEventListener('click', () => {
         const topic = topicInput.value.trim();
         if (topic) {
@@ -331,6 +344,61 @@ document.addEventListener('DOMContentLoaded', () => {
                 onSuccess: () => {
                     if (projectInsightContainer) {
                         projectInsightContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }
+                }
+            });
+        });
+    });
+
+    const publicationButtons = document.querySelectorAll('.generate-publication-insight');
+
+    publicationButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const publicationItem = button.closest('.publication-item');
+
+            if (!publicationItem) {
+                if (publicationErrorMessage) {
+                    publicationErrorMessage.textContent = 'Unable to identify the selected publication. Please try again.';
+                }
+
+                if (publicationErrorContainer) {
+                    publicationErrorContainer.classList.remove('hidden');
+                }
+                return;
+            }
+
+            const titleElement = publicationItem.querySelector('[data-title]');
+            const descriptionElement = publicationItem.querySelector('[data-description]');
+
+            const title = titleElement?.getAttribute('data-title')?.trim() || titleElement?.textContent?.trim();
+            const description = descriptionElement?.getAttribute('data-description')?.trim() || descriptionElement?.textContent?.trim();
+
+            if (!title && !description) {
+                if (publicationErrorMessage) {
+                    publicationErrorMessage.textContent = 'No details were found for the selected publication. Please try another publication.';
+                }
+
+                if (publicationErrorContainer) {
+                    publicationErrorContainer.classList.remove('hidden');
+                }
+                return;
+            }
+
+            if (publicationInsightTitle) {
+                publicationInsightTitle.textContent = title ? `Publication Insight: ${title}` : 'Publication Insight';
+            }
+
+            const prompt = generatePublicationPrompt(title, description);
+
+            generateInsight(prompt, {
+                loadingElement: publicationLoadingIndicator,
+                resultElement: publicationInsightContainer,
+                errorElement: publicationErrorContainer,
+                textElement: publicationInsightText,
+                errorMessageElement: publicationErrorMessage,
+                onSuccess: () => {
+                    if (publicationInsightContainer) {
+                        publicationInsightContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- add actionable buttons to each publication and supporting UI to show generated insights
- reuse the AI insight service to craft publication-specific prompts with loading, success, and error feedback
- ignore node_modules folders to keep the repository clean

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d553ab1ae0832db9163b4214961cbf