### PR TITLE
Add repository guidelines in AGENTS file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository Guidelines
+
+## Scope
+These instructions apply to the entire `Sundar-Raman-Profile` repository.
+
+## Quick Start
+- Use Node.js 18 or newer.
+- From the `api/` directory run `npm install` to ensure the Google Generative AI client is available.
+- Use `npm run start` from `api/` if you need to exercise the serverless function locally via Vercel.
+
+## Coding Style
+- Keep HTML semantic and accessible: provide `aria` attributes for interactive elements and ensure keyboard operability.
+- Prefer Tailwind utility classes over custom CSS when possible. If you must add custom CSS, place it in `styles.css` and document the intent with a short comment.
+- Write JavaScript in modern ES modules style, favoring `const`/`let` and async/await.
+- Do not commit generated artifacts such as build outputs or additional `node_modules` directories.
+
+## Testing & Validation
+- Run `npm run start` in `api/` to confirm the API bootstraps without runtime errors whenever you modify server-side code.
+- For front-end changes, open `index.html` in a browser and perform a basic smoke test (navigation, collapsible sections, and copy-to-clipboard interactions).
+- Ensure `git status` is clean before requesting review.


### PR DESCRIPTION
## Summary
- add a repository-wide `AGENTS.md` with quick-start steps for the serverless API
- document frontend coding conventions to keep the Tailwind-based UI accessible and consistent
- outline validation expectations for API and UI changes

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d558cea08c832d9d017d809703d88e