### PR TITLE
Set AI generator section expanded by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,19 +74,19 @@
                     class="section-toggle p-2 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
                     data-target="aiGeneratorContent"
                     data-label="AI thought leadership generator"
-                    aria-expanded="false"
+                    aria-expanded="true"
                     aria-controls="aiGeneratorContent"
                 >
-                    <span class="sr-only section-toggle-label">Expand AI thought leadership generator</span>
-                    <svg class="icon-expand h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <span class="sr-only section-toggle-label">Collapse AI thought leadership generator</span>
+                    <svg class="icon-expand h-6 w-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
                     </svg>
-                    <svg class="icon-collapse h-6 w-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg class="icon-collapse h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
                     </svg>
                 </button>
             </div>
-            <div id="aiGeneratorContent" class="section-content space-y-8 mt-6 hidden">
+            <div id="aiGeneratorContent" class="section-content space-y-8 mt-6">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <!-- Context-Aware Insight Generator -->
                 <div class="bg-white p-0 rounded-lg shadow-md border border-gray-200">


### PR DESCRIPTION
## Summary
- make the AI Thought Leadership Generator section expanded on initial load by removing the hidden state
- align the toggle button's default accessibility attributes and icons with the expanded presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55bbfa800832da40d28d60eaff494