### PR TITLE
Remove underline from section headers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -65,17 +65,6 @@ body {
     margin-bottom: 16px;
 }
 
-.section-title::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: 50px;
-    height: 3px;
-    background-color: #6366f1;
-    border-radius: 2px;
-}
-
 #messageBox {
     z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- remove the pseudo-element that drew the decorative underline for section titles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55cc514cc832da1f591d6400f69a1