### PR TITLE
Remove bearer token requirement and add rate limiting

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,9 +7,7 @@
     "start": "vercel dev",
     "test": "node --test"
   },
-  "dependencies": {
-    "@google/generative-ai": "^0.13.0"
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=18.0.0"
   }

--- a/scripts.js
+++ b/scripts.js
@@ -269,12 +269,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 body: JSON.stringify({ prompt })
             });
 
+            let data;
+
             if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.details || 'Unknown error');
+                try {
+                    data = await response.json();
+                } catch (parseError) {
+                    console.warn('Failed to parse error payload:', parseError);
+                }
+
+                const message = data?.error || data?.message || `Request failed with status ${response.status}`;
+                const details = data?.details;
+                throw new Error(details ? `${message} (${details})` : message);
             }
 
-            const data = await response.json();
+            data = data || await response.json();
             const insight = data.candidates?.[0]?.content?.parts?.[0]?.text;
 
             if (insight) {


### PR DESCRIPTION
## Summary
- replace the unused bearer token gate with an origin-based rate limiter so the static client can reach the insight API while throttling abuse
- reset the rate limiter between tests and add a regression suite that verifies the throttle behaviour
- surface server-provided error messages on the front end and prune the unused Google client dependency

## Testing
- `cd api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d56a7ceaac832d955e94fcf9ce539e