### PR TITLE
Allow wildcard CORS in non-production environments

### DIFF
--- a/api/generate-insight.js
+++ b/api/generate-insight.js
@@ -129,18 +129,37 @@ const resetRateLimiter = () => {
     rateLimitBuckets.clear();
 };
 
-const parseAllowedOrigins = () => {
-    const { ALLOWED_ORIGINS } = process.env;
-    if (!ALLOWED_ORIGINS) {
-        return new Set();
+const isProductionEnvironment = () => {
+    const { VERCEL_ENV, NODE_ENV } = process.env;
+
+    if (typeof VERCEL_ENV === 'string' && VERCEL_ENV.length > 0) {
+        return VERCEL_ENV === 'production';
     }
 
-    return new Set(
-        ALLOWED_ORIGINS
-            .split(",")
-            .map((origin) => origin.trim())
-            .filter(Boolean)
-    );
+    if (typeof NODE_ENV === 'string' && NODE_ENV.length > 0) {
+        return NODE_ENV === 'production';
+    }
+
+    return false;
+};
+
+const parseAllowedOrigins = () => {
+    const { ALLOWED_ORIGINS } = process.env;
+
+    if (typeof ALLOWED_ORIGINS === 'string' && ALLOWED_ORIGINS.trim().length > 0) {
+        return new Set(
+            ALLOWED_ORIGINS
+                .split(",")
+                .map((origin) => origin.trim())
+                .filter(Boolean)
+        );
+    }
+
+    if (!isProductionEnvironment()) {
+        return new Set(['*']);
+    }
+
+    return new Set();
 };
 
 const parseAccessTokens = () => {


### PR DESCRIPTION
## Summary
- add environment detection so the API defaults to permissive CORS outside production
- keep strict CORS requirements in production while allowing development requests to succeed
- expand tests to cover the new development fallback behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57cfc4168832dab3f608295f68c80