### PR TITLE
Improve resilience of access token configuration parsing

### DIFF
--- a/api/access-tokens.example.json
+++ b/api/access-tokens.example.json
@@ -1,0 +1,5 @@
+{
+  "tokens": [
+    "replace-with-your-development-token"
+  ]
+}

--- a/api/test/fixtures/access-tokens.json
+++ b/api/test/fixtures/access-tokens.json
@@ -1,0 +1,3 @@
+{
+  "tokens": ["fixture-token"]
+}

--- a/api/test/generate-insight.test.js
+++ b/api/test/generate-insight.test.js
@@ -1,6 +1,8 @@
 const { test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 
+const path = require('node:path');
+
 const handler = require('../generate-insight');
 
 const API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent';
@@ -377,6 +379,126 @@ test('rejects requests without an access token', async () => {
 
     assert.deepEqual(res.statusCalls, [401]);
     assert.deepEqual(res.jsonPayloads[0], { error: 'A valid access token is required.' });
+});
+
+test('loads access tokens from configured file when environment variable is absent', async () => {
+    delete process.env.GENERATE_INSIGHT_ACCESS_TOKENS;
+    process.env.GENERATE_INSIGHT_ACCESS_TOKENS_FILE = path.join(__dirname, 'fixtures/access-tokens.json');
+    process.env.GEMINI_API_KEY = 'key';
+
+    const expectedPayload = { data: 'file-token' };
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => expectedPayload
+    });
+
+    const req = {
+        method: 'POST',
+        headers: {
+            origin: 'https://allowed.example',
+            'content-type': 'application/json',
+            authorization: 'Bearer fixture-token'
+        },
+        body: { prompt: 'Hello' }
+    };
+
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    assert.deepEqual(res.statusCalls, [200]);
+    assert.deepEqual(res.body, expectedPayload);
+});
+
+test('accepts singular environment variable for access tokens', async () => {
+    delete process.env.GENERATE_INSIGHT_ACCESS_TOKENS;
+    process.env.GENERATE_INSIGHT_ACCESS_TOKEN = 'solo-token';
+    process.env.GEMINI_API_KEY = 'key';
+
+    const expectedPayload = { ok: true };
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => expectedPayload
+    });
+
+    const req = {
+        method: 'POST',
+        headers: {
+            origin: 'https://allowed.example',
+            'content-type': 'application/json',
+            authorization: 'Bearer solo-token'
+        },
+        body: { prompt: 'Hello' }
+    };
+
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    assert.deepEqual(res.statusCalls, [200]);
+    assert.deepEqual(res.body, expectedPayload);
+});
+
+test('supports newline separated access tokens in environment variables', async () => {
+    process.env.GENERATE_INSIGHT_ACCESS_TOKENS = 'first-token\nsecond-token\n';
+    process.env.GEMINI_API_KEY = 'key';
+
+    const expectedPayload = { ok: true };
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => expectedPayload
+    });
+
+    const req = {
+        method: 'POST',
+        headers: {
+            origin: 'https://allowed.example',
+            'content-type': 'application/json',
+            authorization: 'Bearer second-token'
+        },
+        body: { prompt: 'Hello' }
+    };
+
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    assert.deepEqual(res.statusCalls, [200]);
+    assert.deepEqual(res.body, expectedPayload);
+});
+
+test('resolves relative access token file paths from environment variables', async () => {
+    delete process.env.GENERATE_INSIGHT_ACCESS_TOKENS;
+    delete process.env.GENERATE_INSIGHT_ACCESS_TOKENS_FILE;
+    process.env.ACCESS_TOKENS_FILE = './test/fixtures/access-tokens.json';
+    process.env.GEMINI_API_KEY = 'key';
+
+    const expectedPayload = { ok: true };
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => expectedPayload
+    });
+
+    const req = {
+        method: 'POST',
+        headers: {
+            origin: 'https://allowed.example',
+            'content-type': 'application/json',
+            authorization: 'Bearer fixture-token'
+        },
+        body: { prompt: 'Hello' }
+    };
+
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    assert.deepEqual(res.statusCalls, [200]);
+    assert.deepEqual(res.body, expectedPayload);
 });
 
 test('rejects requests with an invalid access token', async () => {


### PR DESCRIPTION
## Summary
- allow tokens to be loaded from multiple environment variable names, newline-separated strings, and JSON arrays, and expand fallback file path resolution for local configs
- harden file-based parsing by trimming content and guarding invalid JSON before returning tokens
- exercise new configuration paths with tests covering singular env vars, newline lists, and relative file references

## Testing
- `cd api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d58958677c832d8e4dec2d19008094