### PR TITLE
Add development fallback tokens and tests

### DIFF
--- a/api/access-tokens.example.json
+++ b/api/access-tokens.example.json
@@ -1,5 +1,5 @@
 {
   "tokens": [
-    "replace-with-your-development-token"
+    "local-development-token"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
                     <p id="accessTokenHelp" class="text-xs text-blue-800 space-y-1">
                         <span class="block">The token never leaves your browser storage until you generate an insight. It is required to prevent unauthorized use of the AI proxy.</span>
                         <span class="block">You will also need to supply your own <a href="https://ai.google.dev/gemini-api/docs/api-key" class="underline text-blue-700 hover:text-blue-900" target="_blank" rel="noopener noreferrer">Gemini API key</a> when deploying this experience. The linked guide explains how to create one.</span>
+                        <span class="block">For local development, use the token defined in <code>api/access-tokens.example.json</code> (default: <span class="font-semibold">local-development-token</span>).</span>
                     </p>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-8">


### PR DESCRIPTION
## Summary
- allow the insight API to load access tokens from the example configuration when no other tokens are provided outside production
- expand the serverless test suite to cover the development fallback and production guard rails
- document the default local-development token in the AI generator instructions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d58e937e14832d86005b9f3a39e2fc