### PR TITLE
Clarify access token configuration requirements

### DIFF
--- a/api/generate-insight.js
+++ b/api/generate-insight.js
@@ -341,7 +341,10 @@ module.exports = async (req, res) => {
     const rawAccessToken = getAccessTokenFromHeader(req);
     if (!rawAccessToken || !accessTokens.has(rawAccessToken)) {
         console.info('Rejected request due to missing or invalid access token.');
-        return res.status(401).json({ error: "A valid access token is required." });
+        return res.status(401).json({
+            error: "A valid insight generator access token is required.",
+            details: "Configure GENERATE_INSIGHT_ACCESS_TOKENS (or access-tokens.json) with the same token you enter in the UI. This token is separate from your Gemini API key."
+        });
     }
 
     const hashedToken = hashToken(rawAccessToken);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "ai-thought-leadership-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-thought-leadership-api",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/api/test/generate-insight.test.js
+++ b/api/test/generate-insight.test.js
@@ -43,6 +43,10 @@ function createMockResponse() {
 }
 
 const VALID_TOKEN = 'valid-token';
+const ACCESS_TOKEN_ERROR_RESPONSE = {
+    error: 'A valid insight generator access token is required.',
+    details: 'Configure GENERATE_INSIGHT_ACCESS_TOKENS (or access-tokens.json) with the same token you enter in the UI. This token is separate from your Gemini API key.'
+};
 
 const authorize = (headers = {}) => ({
     ...headers,
@@ -378,7 +382,7 @@ test('rejects requests without an access token', async () => {
     await handler(req, res);
 
     assert.deepEqual(res.statusCalls, [401]);
-    assert.deepEqual(res.jsonPayloads[0], { error: 'A valid access token is required.' });
+    assert.deepEqual(res.jsonPayloads[0], ACCESS_TOKEN_ERROR_RESPONSE);
 });
 
 test('loads access tokens from configured file when environment variable is absent', async () => {
@@ -428,7 +432,7 @@ test('rejects requests with an invalid access token', async () => {
     await handler(req, res);
 
     assert.deepEqual(res.statusCalls, [401]);
-    assert.deepEqual(res.jsonPayloads[0], { error: 'A valid access token is required.' });
+    assert.deepEqual(res.jsonPayloads[0], ACCESS_TOKEN_ERROR_RESPONSE);
 });
 
 test('retries Gemini calls on transient failures', async () => {

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
                     />
                     <p id="accessTokenHelp" class="text-xs text-blue-800 space-y-1">
                         <span class="block">The token never leaves your browser storage until you generate an insight. It is required to prevent unauthorized use of the AI proxy.</span>
+                        <span class="block">Create this access token yourself and add it to the <code>GENERATE_INSIGHT_ACCESS_TOKENS</code> environment variable (or the <code>api/access-tokens.json</code> file) so the server can validate it. This token is distinct from your Gemini API key.</span>
                         <span class="block">You will also need to supply your own <a href="https://ai.google.dev/gemini-api/docs/api-key" class="underline text-blue-700 hover:text-blue-900" target="_blank" rel="noopener noreferrer">Gemini API key</a> when deploying this experience. The linked guide explains how to create one.</span>
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- clarify the 401 response from the generate insight endpoint so it explains how to configure the required access token separately from the Gemini API key
- update the frontend helper copy to spell out where to register the access token and that it is distinct from the Gemini key
- add corresponding test expectations and lock down dependencies with a package-lock to capture the local install state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d59120a94c832d98d500c41e27fce8