### PR TITLE
Fix frontend test module path and npm test glob

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
     "build": "echo \"no build step\"",
     "dev": "vercel dev",
     "start": "vercel dev",
-    "test": "node --test \"./test/**/*.test.js\""
+    "test": "node --test ./test/*.test.js"
   },
   "dependencies": {}
 }

--- a/api/test/frontend.test.js
+++ b/api/test/frontend.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-const modulePath = pathToFileURL(path.join(__dirname, '..', '..', 'js', 'modules', 'ai-generator.js')).href;
+const modulePath = pathToFileURL(path.join(__dirname, '..', 'public', 'js', 'modules', 'ai-generator.js')).href;
 
 class MockElement {
     constructor(tagName) {


### PR DESCRIPTION
## Summary
- update the frontend unit test to import the ai-generator module from the public/js/modules directory
- adjust the npm test script glob so Node runs the test files that exist in the api/test folder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d645d04564832d900b637b9a1f2cfc