### PR TITLE
Add module scope package.json for public JS assets

### DIFF
--- a/api/public/js/package.json
+++ b/api/public/js/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add a package.json with `type: module` in `api/public/js` so Node treats the front-end scripts as ES modules during tests
- verify the existing relative imports in the `modules` directory remain valid under the module scope

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6483e12a0832d8cb1409e456b0f37