### PR TITLE
Update overview highlights with Shell and new focus areas

### DIFF
--- a/api/public/index.html
+++ b/api/public/index.html
@@ -59,11 +59,13 @@
                 </p>
                 <div class="flex flex-wrap justify-center md:justify-start gap-4 text-sm font-medium">
                     <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Kimberly-Clark</span>
-                    <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Ex-Shell</span>
+                    <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Shell</span>
+                    <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">IBM</span>
                     <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">AI Strategy</span>
                     <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Digital Transformation</span>
                     <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Supply Chain</span>
                     <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Smart Manufacturing</span>
+                    <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full">Industry 4.0 focus</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- replace the overview highlight tag for Ex-Shell with Shell
- add highlight chips for IBM and Industry 4.0 focus to emphasize additional experience areas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e6b1e5cc832db263ae0d37f108c8